### PR TITLE
Add basic Vercel deployment files

### DIFF
--- a/api/imagenologia.py
+++ b/api/imagenologia.py
@@ -1,0 +1,21 @@
+"""API simple para Vercel escrita en Python 3.9"""
+
+# Importamos BaseHTTPRequestHandler para manejar las solicitudes HTTP
+from http.server import BaseHTTPRequestHandler
+
+
+class handler(BaseHTTPRequestHandler):
+    """Manejador principal de la función"""
+
+    def do_GET(self):
+        """Responde a una solicitud GET con un mensaje simple"""
+        # Indicamos que la respuesta fue exitosa
+        self.send_response(200)
+
+        # Establecemos las cabeceras de la respuesta
+        self.send_header("Content-type", "text/plain; charset=utf-8")
+        self.end_headers()
+
+        # Enviamos el cuerpo de la respuesta
+        mensaje = "Respuesta de la API de imagenología"
+        self.wfile.write(mensaje.encode("utf-8"))

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<!-- Pagina principal de la aplicacion -->
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Imagenología Médica</title>
+</head>
+<body>
+    <!-- Encabezado principal -->
+    <h1>Bienvenido a Imagenología Médica</h1>
+    <!-- Breve descripcion -->
+    <p>Esta aplicación demuestra una API sencilla desplegada en Vercel.</p>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "api/imagenologia.py",
+      "use": "@vercel/python",
+      "config": { "runtime": "python3.9" }
+    }
+  ],
+  "routes": [
+    { "src": "/api/imagenologia", "dest": "api/imagenologia.py" },
+    { "src": "/(.*)", "dest": "/public/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a simple landing page in `public/index.html`
- implement a Python 3.9 API handler for Vercel
- configure `vercel.json` to deploy the API and static page

## Testing
- `python3 -m py_compile api/imagenologia.py`

------
https://chatgpt.com/codex/tasks/task_e_6848953ab7c0832bb002577d850c8079