### PR TITLE
Add prompt query param to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,25 @@ python app.py
 ```
 
 El script imprimirá la respuesta devuelta por la API.
+
+## Uso de la API
+
+La función desplegada en Vercel se encuentra en `/api/imagenologia` y ahora
+acepta un parámetro `prompt` mediante la cadena de consulta. Responde en formato
+JSON con el valor del `prompt` recibido o un mensaje de error si el parámetro no
+se proporciona.
+
+Ejemplo de llamada:
+
+```bash
+curl "https://<tu-deploy>.vercel.app/api/imagenologia?prompt=hola"
+```
+
+Respuesta esperada:
+
+```json
+{
+  "prompt": "hola",
+  "mensaje": "Solicitud recibida"
+}
+```


### PR DESCRIPTION
## Summary
- add query parameter parsing in API and return JSON
- document new API interface in README

## Testing
- `python3 -m py_compile api/imagenologia.py`


------
https://chatgpt.com/codex/tasks/task_e_68571554d1d4832b8c24224b73a7c210